### PR TITLE
Pass BackendTLSPolicyConflictResolution conformance test

### DIFF
--- a/pkg/controller/backendtlspolicy_controller.go
+++ b/pkg/controller/backendtlspolicy_controller.go
@@ -57,11 +57,54 @@ func (r *BackendTLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Find all Gateways that use this policy (via Services referenced in HTTPRoutes)
 	gateways := r.State.GetGateways()
 	routes := r.State.GetHTTPRoutes()
+	allPolicies := r.State.GetBackendTLSPolicies()
 
-	targetRef := policy.Spec.TargetRefs[0]
-	targetedServiceName := types.NamespacedName{
-		Namespace: policy.Namespace,
-		Name:      string(targetRef.Name),
+	// Conflict resolution
+	isConflicted := false
+	var conflictingPolicy string
+	for _, targetRef := range policy.Spec.TargetRefs {
+		if string(targetRef.Group) != "" && string(targetRef.Group) != "gateway.networking.k8s.io" {
+			continue
+		}
+		if string(targetRef.Kind) != "Service" {
+			continue
+		}
+
+		targetSvcNamespace := policy.Namespace
+		targetSvcName := string(targetRef.Name)
+
+		for _, p := range allPolicies {
+			if p.Namespace == policy.Namespace && p.Name == policy.Name {
+				continue
+			}
+
+			for _, t := range p.Spec.TargetRefs {
+				if (string(t.Group) == "" || string(t.Group) == "gateway.networking.k8s.io") && string(t.Kind) == "Service" {
+					if p.Namespace == targetSvcNamespace && string(t.Name) == targetSvcName {
+						// Found another policy targeting the same service
+						// Check if it's older
+						if p.CreationTimestamp.Time.Before(policy.CreationTimestamp.Time) {
+							isConflicted = true
+							conflictingPolicy = fmt.Sprintf("%s/%s", p.Namespace, p.Name)
+							break
+						}
+						if p.CreationTimestamp.Time.Equal(policy.CreationTimestamp.Time) {
+							if p.Namespace < policy.Namespace || (p.Namespace == policy.Namespace && p.Name < policy.Name) {
+								isConflicted = true
+								conflictingPolicy = fmt.Sprintf("%s/%s", p.Namespace, p.Name)
+								break
+							}
+						}
+					}
+				}
+			}
+			if isConflicted {
+				break
+			}
+		}
+		if isConflicted {
+			break
+		}
 	}
 
 	// Validate CA certificates
@@ -115,10 +158,16 @@ func (r *BackendTLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		resolvedRefsMessage = fmt.Sprintf("Unresolved or invalid CA certificate references: %v", unresolvedRefs)
 	}
 
+	if isConflicted {
+		acceptedStatus = metav1.ConditionFalse
+		acceptedReason = gatewayv1.PolicyReasonConflicted
+		acceptedMessage = fmt.Sprintf("Conflicted with older policy: %s", conflictingPolicy)
+	}
+
 	var ancestors []gatewayv1.PolicyAncestorStatus
 
 	for _, gw := range gateways {
-		usesService := false
+		usesPolicy := false
 		for _, route := range routes {
 			if route.MatchesGateway(gw.Gateway, ControllerName) {
 				for _, rule := range route.Spec.Rules {
@@ -128,23 +177,29 @@ func (r *BackendTLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Req
 							if backendRef.Namespace != nil {
 								ns = string(*backendRef.Namespace)
 							}
-							if ns == targetedServiceName.Namespace && string(backendRef.Name) == targetedServiceName.Name {
-								usesService = true
-								break
+
+							for _, targetRef := range policy.Spec.TargetRefs {
+								if ns == policy.Namespace && string(backendRef.Name) == string(targetRef.Name) {
+									usesPolicy = true
+									break
+								}
 							}
 						}
+						if usesPolicy {
+							break
+						}
 					}
-					if usesService {
+					if usesPolicy {
 						break
 					}
 				}
 			}
-			if usesService {
+			if usesPolicy {
 				break
 			}
 		}
 
-		if usesService {
+		if usesPolicy {
 			ancestors = append(ancestors, gatewayv1.PolicyAncestorStatus{
 				AncestorRef: gatewayv1.ParentReference{
 					Group:     state.Ptr(gatewayv1.Group("gateway.networking.k8s.io")),

--- a/pkg/state/gateway.go
+++ b/pkg/state/gateway.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -295,6 +296,23 @@ func getPathLen(m *InternalMatch) int {
 }
 
 func (s *GatewayState) BuildInternalRoutes(routes []*HTTPRouteState, services map[types.NamespacedName]*corev1.Service, backendTLSPolicies []*gatewayv1.BackendTLSPolicy, configMaps map[types.NamespacedName]*corev1.ConfigMap, controllerName string) []InternalRoute {
+	// Sort policies by creation timestamp, then by namespaced name to ensure deterministic conflict resolution.
+	sort.SliceStable(backendTLSPolicies, func(i, j int) bool {
+		if backendTLSPolicies[i].CreationTimestamp.Time.Before(backendTLSPolicies[j].CreationTimestamp.Time) {
+			return true
+		}
+		if backendTLSPolicies[i].CreationTimestamp.Time.After(backendTLSPolicies[j].CreationTimestamp.Time) {
+			return false
+		}
+		if backendTLSPolicies[i].Namespace < backendTLSPolicies[j].Namespace {
+			return true
+		}
+		if backendTLSPolicies[i].Namespace > backendTLSPolicies[j].Namespace {
+			return false
+		}
+		return backendTLSPolicies[i].Name < backendTLSPolicies[j].Name
+	})
+
 	var internalRoutes []InternalRoute
 
 	for _, listener := range s.Spec.Listeners {
@@ -432,6 +450,9 @@ func (s *GatewayState) BuildInternalRoutes(routes []*HTTPRouteState, services ma
 						// Check for BackendTLSPolicy
 						var tlsConfig *InternalTLSConfig
 						for _, policy := range backendTLSPolicies {
+							if tlsConfig != nil {
+								break
+							}
 							for _, targetRef := range policy.Spec.TargetRefs {
 								if string(targetRef.Group) == "" && string(targetRef.Kind) == "Service" &&
 									string(targetRef.Name) == string(backendRef.Name) &&

--- a/pkg/state/gateway_test.go
+++ b/pkg/state/gateway_test.go
@@ -484,6 +484,151 @@ func TestBuildInternalRoutes(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "BackendTLSPolicy conflict resolution - oldest wins",
+			gateway: &GatewayState{
+				Gateway: &gatewayv1.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "reference-gateway",
+						Namespace: "default",
+					},
+					Spec: gatewayv1.GatewaySpec{
+						Listeners: []gatewayv1.Listener{
+							{
+								Name:     "http",
+								Protocol: gatewayv1.HTTPProtocolType,
+							},
+						},
+					},
+				},
+			},
+			routes: []*HTTPRouteState{
+				{
+					HTTPRoute: &gatewayv1.HTTPRoute{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "route1",
+							Namespace: "default",
+						},
+						Spec: gatewayv1.HTTPRouteSpec{
+							CommonRouteSpec: gatewayv1.CommonRouteSpec{
+								ParentRefs: []gatewayv1.ParentReference{
+									{
+										Name: "reference-gateway",
+									},
+								},
+							},
+							Hostnames: []gatewayv1.Hostname{"example.com"},
+							Rules: []gatewayv1.HTTPRouteRule{
+								{
+									BackendRefs: []gatewayv1.HTTPBackendRef{
+										{
+											BackendRef: gatewayv1.BackendRef{
+												BackendObjectReference: gatewayv1.BackendObjectReference{
+													Kind: Ptr(gatewayv1.Kind("Service")),
+													Name: "backend-svc",
+													Port: Ptr(gatewayv1.PortNumber(80)),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Status: gatewayv1.HTTPRouteStatus{
+							RouteStatus: gatewayv1.RouteStatus{
+								Parents: []gatewayv1.RouteParentStatus{
+									{
+										ParentRef: gatewayv1.ParentReference{
+											Name: "reference-gateway",
+										},
+										ControllerName: gatewayv1.GatewayController(controllerName),
+										Conditions: []metav1.Condition{
+											{
+												Type:   string(gatewayv1.RouteConditionAccepted),
+												Status: metav1.ConditionTrue,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			services: map[types.NamespacedName]*corev1.Service{
+				{Namespace: "default", Name: "backend-svc"}: {
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Port: 80,
+							},
+						},
+					},
+				},
+			},
+			backendTLSPolicies: []*gatewayv1.BackendTLSPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "policy-new",
+						Namespace:         "default",
+						CreationTimestamp: metav1.NewTime(metav1.Now().Add(10 * 1e9)),
+					},
+					Spec: gatewayv1.BackendTLSPolicySpec{
+						TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+							{
+								LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+									Group: "",
+									Kind:  "Service",
+									Name:  "backend-svc",
+								},
+							},
+						},
+						Validation: gatewayv1.BackendTLSPolicyValidation{
+							Hostname: "new.example.com",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "policy-old",
+						Namespace:         "default",
+						CreationTimestamp: metav1.NewTime(metav1.Now().Add(-10 * 1e9)),
+					},
+					Spec: gatewayv1.BackendTLSPolicySpec{
+						TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+							{
+								LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+									Group: "",
+									Kind:  "Service",
+									Name:  "backend-svc",
+								},
+							},
+						},
+						Validation: gatewayv1.BackendTLSPolicyValidation{
+							Hostname: "old.example.com",
+						},
+					},
+				},
+			},
+			expected: []InternalRoute{
+				{
+					Hostnames: []string{"example.com"},
+					Rules: []InternalRule{
+						{
+							Backend: &InternalBackend{
+								Host:        "backend-svc.default.svc.cluster.local",
+								Port:        80,
+								AppProtocol: Ptr("https"),
+								TLSConfig: &InternalTLSConfig{
+									Hostname: "old.example.com",
+									CACerts:  nil,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/e2e/conformance_test.go
+++ b/tests/e2e/conformance_test.go
@@ -102,6 +102,7 @@ func TestConformance(t *testing.T) {
 		tests.HTTPRouteInvalidBackendRefUnknownKind,
 		tests.HTTPRouteBackendProtocolH2C,
 		tests.BackendTLSPolicy,
+		tests.BackendTLSPolicyConflictResolution,
 	}
 
 	cSuite.Setup(t, selectedTests)


### PR DESCRIPTION
This PR implements BackendTLSPolicy conflict resolution as required by the Gateway API specification.

Changes:
- Implemented sorting of BackendTLSPolicies by creation timestamp and namespaced name in pkg/state/gateway.go.
- Ensured only the oldest policy is applied to a backend in BuildInternalRoutes.
- Updated BackendTLSPolicyReconciler in pkg/controller/backendtlspolicy_controller.go to detect conflicts and report them in the status with Accepted: False and reason Conflicted.
- Added BackendTLSPolicyConflictResolution to the list of conformance tests in tests/e2e/conformance_test.go.
- Added a unit test in pkg/state/gateway_test.go to verify conflict resolution.

This PR was generated by the gemini-3-flash-preview model.

Issue #65